### PR TITLE
xarray_scipy.signal.hilbert: readd coordinates for dim when N is used

### DIFF
--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -318,3 +318,34 @@ def test_hilbert():
     signal = xr.DataArray(signal, dims=["time"])
     result = hilbert(signal, dim="time")
     assert np.allclose(np.abs(result).data, np.ones(nsamples) * A)
+
+
+def test_hilbert__N():
+    duration = 10.0
+    fs = 8000.0
+    nsamples = int(fs * duration)
+    f = 100.0
+    A = 2.0
+    N = 100
+    dim = "time"
+    signal = A * np.sin(2.0 * np.pi * f * np.arange(nsamples) / fs)
+    signal = xr.DataArray(signal, dims=[dim], coords={dim: np.arange(nsamples)})
+    result = hilbert(signal, N=N, dim=dim)
+    assert len(result) == N
+    assert dim in result.coords
+
+
+def test_hilbert__N_without_coords():
+
+    duration = 10.0
+    fs = 8000.0
+    nsamples = int(fs * duration)
+    f = 100.0
+    A = 2.0
+    N = 100
+    dim = "time"
+    signal = A * np.sin(2.0 * np.pi * f * np.arange(nsamples) / fs)
+    signal = xr.DataArray(signal, dims=[dim])
+    result = hilbert(signal, N=N, dim=dim)
+    assert len(result) == N
+    assert dim not in result.coords

--- a/xarray_scipy/signal.py
+++ b/xarray_scipy/signal.py
@@ -133,6 +133,11 @@ def hilbert(x: xr.DataArray, dim: str, N: int = None, keep_attrs=None) -> xr.Dat
 
     """
 
+    exclude_dims = []
+
+    if N is not None:
+        exclude_dims.append(dim)
+
     result = xr.apply_ufunc(
         scipy.signal.hilbert,
         x,
@@ -142,11 +147,7 @@ def hilbert(x: xr.DataArray, dim: str, N: int = None, keep_attrs=None) -> xr.Dat
         input_core_dims=[
             (dim,),
         ],
-        exclude_dims=set(
-            [
-                dim,
-            ]
-        ),
+        exclude_dims=set(exclude_dims),
         output_core_dims=[
             (dim,),
         ],
@@ -155,9 +156,23 @@ def hilbert(x: xr.DataArray, dim: str, N: int = None, keep_attrs=None) -> xr.Dat
                 dim: N if N is not None else len(x[dim]),
             },
         },
-        dask="parallelized",
+        dask="parallelized",  # np.asarray is used within scipy.signal.hilbert
         keep_attrs=_keep_attrs(keep_attrs),
     )
+
+    if N is not None and dim in x.coords:
+
+        def linspace(arr, N):
+            # np.linspace does not function with datetimes
+            arr = np.asarray(arr)
+            delta = arr.max() - arr.min()
+            result = np.arange(N) * delta / N
+            return result
+
+        result = result.assign_coords(
+            {dim: x.coords[dim].interp({dim: linspace(x.coords[dim], N)})}
+        )
+
     return result
 
 


### PR DESCRIPTION
When exclude_dims is set, the coordinates for that dimension are dropped
as they no longer have to match. Let's only set exclude_dims when N is
passed in, and in that case also recompute the coordinates.